### PR TITLE
Add one hot encoding for labels

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -54,11 +54,12 @@ class Main {
         AssertionUtils.validateTrainImages(trainImages);
 //        /* Load each image */
         List<int[][]> eachImage = Util.getEachImage(trainImages);
+
         /* Uncomment to view the first image */
 //        displayImage(eachImage.get(90));
 
         /* Load each label */
-        List<Integer> eachLabel = Util.extractLabels(trainLabels, 8);
+        List<Integer> extractedLabels = Util.extractLabels(trainLabels, 8);
         AssertionUtils.validateTrainLabels(trainLabels);
 
         /* Uncomment to go through every label */
@@ -69,8 +70,10 @@ class Main {
         /* Normalizing pixel values to 0 - 1, check docs to see why float */
         List<float[][]> normalizedPixels = NeuralNWUtils.normalizePixels(eachImage);
 
-        /* TODO : One hot encode labels
-        * TODO : Initialize weights using min bias
+        /* One hot encode training labels */
+        List<int[]> encodedTrainLabels = Util.encodeLabels(extractedLabels);
+
+        /* TODO : Initialize weights using min bias
         * TODO : Setup Activation function
         * TODO : Calculate loss */
 

--- a/src/Util.java
+++ b/src/Util.java
@@ -49,4 +49,21 @@ public class Util {
         return result;
     }
 
+    public static List<int[]> encodeLabels(List<Integer> labelData) {
+        /* One hot encode label data for Softmax activation compatibility
+        *  In neural networks, we often use a softmax function in the last layer for classification, which outputs a probability distribution.
+        *  The one-hot encoding helps compare the model's predicted probabilities with the true class in a clear way */
+        List<int[]> resultEncoding = new ArrayList<>();
+        for(Integer label : labelData) {
+            // To hold numbers 0 - 9
+            // Label `3` → One-hot encoded as `[0, 0, 0, 1, 0, 0, 0, 0, 0, 0]
+            int[] oneHotArray = new int[10];
+            oneHotArray[label] = 1;
+            resultEncoding.add(oneHotArray);
+
+        }
+
+        return resultEncoding;
+    }
+
 }


### PR DESCRIPTION
One-hot encoding is a way of representing categorical labels as numerical arrays. In the **MNIST dataset**, where the labels (digits) range from 0 to 9, we use one-hot encoding to convert each digit into a vector with **10 elements**, where only **one** element is **1** (hot), and the rest are **0** (cold).

#### Why do we need one-hot encoding for labels?

1. **Machine learning models work better with numbers** – Many models, especially neural networks, perform better when labels are represented as numerical arrays rather than raw numbers.
    
2. **Avoiding misleading relationships** – If we keep the labels as just numbers (0-9), the model might assume that **9 is greater than 2**, which is not true in classification problems.
    
3. **Softmax activation compatibility** – In neural networks, we often use a softmax function in the last layer for classification, which outputs a probability distribution. The one-hot encoding helps compare the model's predicted probabilities with the true class in a clear way.
    

#### Example:

- Label `3` → One-hot encoded as `[0, 0, 0, 1, 0, 0, 0, 0, 0, 0]`
- Label `7` → One-hot encoded as `[0, 0, 0, 0, 0, 0, 0, 1, 0, 0]`

This helps the model learn which category a digit belongs to without assuming any numerical relationship between labels.